### PR TITLE
Update _nucleo-outline.scss

### DIFF
--- a/src/assets/scss/now-ui-kit/_nucleo-outline.scss
+++ b/src/assets/scss/now-ui-kit/_nucleo-outline.scss
@@ -8,11 +8,11 @@ Created using IcoMoon - icomoon.io
 
 @font-face {
   font-family: 'Nucleo Outline';
-  src: url('../fonts/nucleo-outline.eot');
-  src: url('../fonts/nucleo-outline.eot') format('embedded-opentype'),
-  url('../fonts/nucleo-outline.woff2') format('woff2'),
-  url('../fonts/nucleo-outline.woff') format('woff'),
-  url('../fonts/nucleo-outline.ttf') format('truetype');
+  src: url('../../fonts/nucleo-outline.eot');
+  src: url('../../fonts/nucleo-outline.eot') format('embedded-opentype'),
+  url('../../fonts/nucleo-outline.woff2') format('woff2'),
+  url('../../fonts/nucleo-outline.woff') format('woff'),
+  url('../../fonts/nucleo-outline.ttf') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Fix relative paths to font assets
This targets issue [#96](https://github.com/creativetimofficial/now-ui-kit/issues/96#issue-539285465)